### PR TITLE
Correct misspelled name in GopherCon 2015 article

### DIFF
--- a/content/gophercon2015.article
+++ b/content/gophercon2015.article
@@ -50,6 +50,6 @@ The [[http://gophercon.com/schedule/10july/][hack day]] was also a ton of fun,
 with hours of [[https://www.youtube.com/playlist?list=PL2ntRZ1ySWBeHqlHM8DmvS8axgbrpvF9b][lightning talks]] and a range of activities from programming robots
 to a Magic: the Gathering tournament.
 
-Huge thanks to the event organizers Brian Ketelsen and Eric St. Martin and
+Huge thanks to the event organizers Brian Ketelsen and Erik St. Martin and
 their production team, the sponsors, the speakers, and the attendees for making
 this such a fun and action-packed conference. Hope to see you there next year!


### PR DESCRIPTION
Someone pointed this out today.