### PR TITLE
Adjust the defer function calls' position in article defer-panic-and-recover

### DIFF
--- a/content/defer-panic-and-recover.article
+++ b/content/defer-panic-and-recover.article
@@ -37,16 +37,16 @@ This works, but there is a bug. If the call to os.Create fails, the function wil
  
 	func CopyFile(dstName, srcName string) (written int64, err error) {
 	    src, err := os.Open(srcName)
+	    defer src.Close()
 	    if err != nil {
 	        return
 	    }
-	    defer src.Close()
 
 	    dst, err := os.Create(dstName)
+	    defer dst.Close()
 	    if err != nil {
 	        return
 	    }
-	    defer dst.Close()
 
 	    return io.Copy(dst, src)
 	}


### PR DESCRIPTION
In the previous code, defer function calls are put after the error
handling, so if errors occur, the function returns before the defer
statements are executed, thus, the read/write streams won't be closed.