### PR TITLE
defer-panic-recover: Defer statements are stored in a LIFO stack, not a list

### DIFF
--- a/content/defer-panic-and-recover.article
+++ b/content/defer-panic-and-recover.article
@@ -9,7 +9,7 @@ Andrew Gerrand
 Go has the usual mechanisms for control flow: if, for, switch, goto.  It also has the go statement to run code in a separate goroutine.  Here I'd like to discuss some of the less common ones: defer, panic, and recover.
 
  
-A *defer*statement* pushes a function call onto a list. The list of saved calls is executed after the surrounding function returns. Defer is commonly used to simplify functions that perform various clean-up actions.
+A *defer*statement* pushes a function call onto a stack. The stack of saved calls is executed after the surrounding function returns. Defer is commonly used to simplify functions that perform various clean-up actions.
 
  
 For example, let's look at a function that opens two files and copies the contents of one file to the other:


### PR DESCRIPTION
Defer statements are stored in a LIFO stack, per the second simple rule listed later in this blog post. Correct the list reference to avoid confusion.