### PR TITLE
template: remove dead "Go on Google+" link from sidebar

### DIFF
--- a/template/root.tmpl
+++ b/template/root.tmpl
@@ -101,7 +101,6 @@
 	<li><a href='//tour.golang.org/'>A Tour of Go</a></li>
 	<li><a href='//golang.org/doc/'>Go Documentation</a></li>
 	<li><a href='//groups.google.com/group/golang-nuts'>Go Mailing List</a></li>
-	<li><a href='//plus.google.com/101406623878176903605'>Go on Google+</a></li>
 	<li><a href='//plus.google.com/communities/114112804251407510571'>Go+ Community</a></li>
 	<li><a href='//twitter.com/golang'>Go on Twitter</a></li>
 	</ul>


### PR DESCRIPTION
I was reading the blog post and noticed this dead link. Consider removing it.

(The G+ community link below this one is still working, at least until the service shuts down.)