### PR TITLE
Avoid using the word "random" to describe map iteration

### DIFF
--- a/content/go-maps-in-action.article
+++ b/content/go-maps-in-action.article
@@ -171,7 +171,7 @@ To write to the counter, take the write lock:
 * Iteration order
 
 When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next.
-Since the release of Go 1.0, the runtime ensures that the order of the keys changes every time the map is iterated.
+Since the release of Go 1.0, the runtime changes the order of the keys every time the map is iterated.
 Programmers had begun to rely on the stable iteration order of early versions of Go, which varied between implementations, leading to portability bugs.
 If you require a stable iteration order you must maintain a separate data structure that specifies that order.
 This example uses a separate sorted slice of keys to print a `map[int]string` in key order:

--- a/content/go-maps-in-action.article
+++ b/content/go-maps-in-action.article
@@ -171,7 +171,7 @@ To write to the counter, take the write lock:
 * Iteration order
 
 When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next.
-Since the release of Go 1.0, the runtime changes the order of the keys every time the map is iterated.
+Since the release of Go 1.0, the iteration order for most maps can change between iterations.
 Programmers had begun to rely on the stable iteration order of early versions of Go, which varied between implementations, leading to portability bugs.
 If you require a stable iteration order you must maintain a separate data structure that specifies that order.
 This example uses a separate sorted slice of keys to print a `map[int]string` in key order:

--- a/content/go-maps-in-action.article
+++ b/content/go-maps-in-action.article
@@ -171,7 +171,7 @@ To write to the counter, take the write lock:
 * Iteration order
 
 When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next.
-Since the release of Go 1.0, the runtime has randomized map iteration order.
+Since the release of Go 1.0, the runtime ensures that the order of the keys changes every time the map is iterated.
 Programmers had begun to rely on the stable iteration order of early versions of Go, which varied between implementations, leading to portability bugs.
 If you require a stable iteration order you must maintain a separate data structure that specifies that order.
 This example uses a separate sorted slice of keys to print a `map[int]string` in key order:


### PR DESCRIPTION
This article is cited as a source of confusion on whether map iteration is "random", something that is objectively correct because woefully underdefined, but that some have assumed to mean "uniformly random" - which is not:
- https://twitter.com/wallyqs/status/1135719212024909824
- https://twitter.com/ultimateboy/status/1135325432624975872