### PR TITLE
blog: fixes a typo

### DIFF
--- a/content/go1.13-errors.article
+++ b/content/go1.13-errors.article
@@ -65,7 +65,7 @@ value as a more specific type.
 	func (e *NotFoundError) Error() string { return e.Name + ": not found" }
 
 	if e, ok := err.(*NotFoundError); ok {
-		// e.Name wasn't found
+		// e.Name was found
 	}
 
 ### Adding information


### PR DESCRIPTION
There is typo in following code:
if e, ok := err.(*NotFoundError); ok {
    // e.Name wasn't found
}
If ok == true, means err's type is NotFoundError, then we can refer e's
filed, like e.Name.