### PR TITLE
content: fix italic text in matchlang.article

### DIFF
--- a/content/matchlang.article
+++ b/content/matchlang.article
@@ -55,7 +55,7 @@ This is partly because the boundaries of human languages are not well defined
 and partly because of the legacy of evolving language tag standards.
 In this section we will show some of the messy aspects of handling language tags.
 
-_ Tags with different language codes can indicate the same language_
+_Tags with different language codes can indicate the same language_
 
 For historical and political reasons, many language codes have changed over
 time, leaving languages with an older legacy code as well as a new one.


### PR DESCRIPTION
Fix italic text by removing the space between the underscore and first letter.

Screenshot of issue:

<img width="870" alt="image" src="https://user-images.githubusercontent.com/62928647/86102576-992d0c00-bab3-11ea-9c25-2011cc46b109.png">

Screenshot of fix:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/62928647/86102505-81558800-bab3-11ea-9ac5-3270d55eb56d.png">
