### PR TITLE
Article page: make title not clickable

### DIFF
--- a/_template/article.tmpl
+++ b/_template/article.tmpl
@@ -2,6 +2,7 @@
 
 {{define "title"}}{{.Doc.Title}} - The Go Blog{{end}}
 {{define "content"}}
+	<i class="IsArticle"></i>
 	{{template "doc" .Doc}}
 	{{with .Doc.Related}}
 		<h2>Related articles</h2>

--- a/_template/root.tmpl
+++ b/_template/root.tmpl
@@ -79,6 +79,10 @@
   #content .title {
     margin: 20px 0;
   }
+  .IsArticle + .article .title a {
+    color: #000;
+    pointer-events: none;
+  }
   #content img {
     max-width: 100%;
   }


### PR DESCRIPTION
What problem we solve with this pull request: this is a bad UX to have links to the current page - no value to click and wait to page reload. Also now black font color on article page shows that this is an article page, not main page (useful for full screen mode).

Maybe my code is wrong, maybe `<i class="IsArticle"></i>` is stupid and we need to pass args through Go template, please feel free to fix. I do not know how to add conditional rendering to 
https://github.com/golang/blog/blob/efbf96da94beac4892c106d5e5eff495a7688b52/_template/root.tmpl#L203