### PR TITLE
typo: Fixed indefinite article usage

### DIFF
--- a/_content/maps.article
+++ b/_content/maps.article
@@ -186,7 +186,7 @@ On the other hand, a design that uses a single map with a struct key does away w
 	}
 	hits := make(map[Key]int)
 
-When an Vietnamese person visits the home page,
+When a Vietnamese person visits the home page,
 incrementing (and possibly creating) the appropriate counter is a one-liner:
 
 	hits[Key{"/", "vn"}]++


### PR DESCRIPTION
see https://en.wikipedia.org/wiki/English_articles#Distinction_between_a_and_an